### PR TITLE
Remove `cache/adapter-common` dependency.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,7 @@
         "php": ">=7.1",
         "ramsey/uuid": "^3.0 || ^4.0",
         "psr/log": "^1.0 || ^2.0 || ^3.0",
-        "psr/cache": "^1.0 || ^2.0 || ^3.0",
-        "cache/adapter-common": "^1.0"
+        "psr/cache": "^1.0 || ^2.0 || ^3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0",


### PR DESCRIPTION
This will break `QpsSampler`, but we don't use it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Timing-GmbH/opencensus-php/2)
<!-- Reviewable:end -->
